### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @snyk/jedi


### PR DESCRIPTION
CODEOWNERS was missing or was set to an individual group. Updating CODEOWNERS to point to an R&D team.