### PR TITLE
chore: update codeowners [JEDI-2046]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/jedi
+* @snyk/jedi @snyk/platformeng_jedi


### PR DESCRIPTION
Updates codeowners to append the new github governance managed teams.
For more information, please check:

https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/3428254583/Codeowners+Updates
https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/3504701500/Rollout+of+new+Okta+teams
