### PR TITLE
chore: update codeowners [PRODSEC-10215]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/jedi @snyk/platformeng_jedi
+* @snyk/platformeng_jedi


### PR DESCRIPTION
Updates codeowners to append the new github governance managed teams.
For more information, please check https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4613570586/H1+2026+Team+rename+Updates+to+CODEOWNERS+and+repository+collaborators+to+match+organisation+change

[IMPORTANT]: 
   If your service uses vervet, you probably to run a commane like `make generate` to update the vervet files.
   This is specific to your repository as there is not standardisation on the command to run.
   