### PR TITLE
fix: include v8-microtask headers before nan.h for Node 20.20.2 compat

### DIFF
--- a/src/dump-stacks.cc
+++ b/src/dump-stacks.cc
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <unistd.h>
 
+#include <v8-microtask.h>
+#include <v8-microtask-queue.h>
 #include <nan.h>
 
 #include "stacks.h"


### PR DESCRIPTION
## Summary

Add two defensive `#include` lines so `@snyk/node-dump-stacks` continues to compile against the **nodejs.org-distributed v20.20.2 headers** used by `cimg/node:20.20` (and similar CI images). Without this, every consumer that does a fresh `npm install` on those images hits a hard build failure during the `node-gyp-build` install hook.

## Why this matters

The error surfaces as an opaque `node-gyp` failure during `npm ci` — it looks like an npm or nan problem, but it's neither. It blocks every consumer pipeline using `cimg/node:20.20` the moment their lockfile changes (because that invalidates the install cache and forces a recompile). We hit it on the Snyk registry while removing an unrelated dependency: the lockfile churn alone was enough to break CI repeatedly until we worked out what was going on.

The build error in CI:

```
In file included from /home/circleci/.cache/node-gyp/20.20.2/include/node/v8-initialization.h:13,
                 from /home/circleci/.cache/node-gyp/20.20.2/include/node/v8.h:34,
                 from /home/circleci/.cache/node-gyp/20.20.2/include/node/node.h:73,
                 from ../../../nan/nan.h:67,
                 from ../src/dump-stacks.cc:7:
/home/circleci/.cache/node-gyp/20.20.2/include/node/v8-isolate.h:1204:25:
  error: 'MicrotaskCallback' has not been declared
/home/circleci/.cache/node-gyp/20.20.2/include/node/v8-isolate.h:1209:28:
  error: 'MicrotasksPolicy' has not been declared
/home/circleci/.cache/node-gyp/20.20.2/include/node/v8-isolate.h:1230:7:
  error: 'MicrotasksCompletedCallbackWithData' has not been declared
```

## Root cause

V8 has been splitting `v8.h` into smaller headers (`v8-microtask.h`, `v8-microtask-queue.h`, etc.) for several releases. `v8-isolate.h` references `MicrotaskCallback` and `MicrotasksPolicy` but expects them to already be declared by whoever included it. In **Node 20.20.0**, `v8-isolate.h` self-includes `v8-microtask.h` at line 23, so the chain works:

```c
// node 20.20.0 — v8-isolate.h
#include "v8-microtask.h"   // ← line 23, declares MicrotaskCallback
```

In the **Node 20.20.2 headers distributed via `https://nodejs.org/download/release/v20.20.2/node-v20.20.2-headers.tar.gz`** (which is what `node-gyp` downloads on `cimg/node:20.20`), that include is gone. `v8-isolate.h` references `MicrotaskCallback` at line 1204 without ever pulling in the header that declares it, and compilation breaks for every dependent header chain — including ours via `nan.h → node.h → v8.h → v8-isolate.h`.

This is consistent with the broader V8 header split: callers are now expected to include the leaf headers they need, rather than relying on transitive umbrella includes.

Worth noting: the **mise-distributed** 20.20.2 (`~/.local/share/mise/installs/node/20.20.2/include/node/v8-isolate.h`) still has the include, so the issue is **not** reproducible on every 20.20.2 install. Local macOS builds with mise pass; Linux CI on `cimg/node:20.20` fails. That divergence is exactly why this is so easy to miss.

## The fix

Two lines in `src/dump-stacks.cc`, before the existing `<nan.h>`:

```cpp
#include <v8-microtask.h>
#include <v8-microtask-queue.h>
#include <nan.h>
```

This declares `MicrotaskCallback`, `MicrotasksPolicy`, and `MicrotasksCompletedCallbackWithData` before anything in the `nan.h → v8-isolate.h` chain references them, regardless of whether the v8 headers self-include them. The change is purely additive — on Node versions where `v8-isolate.h` already pulls these in, the second include is a no-op due to header guards.

## Compatibility

Both `v8-microtask.h` and `v8-microtask-queue.h` have shipped in Node ≥17 (verified by checking the header trees on locally-installed Node 17.9, 18.x, 20.x, 22.x, 24.x, 25.x). The package has no `engines.node` field, but `nan` already requires modern V8 APIs, so any environment that builds today supports these headers.

## Verification

- ✅ Local rebuild against Node 20.20.2 (mise) succeeds — no regression on the variant that wasn't failing.
- ⏳ Real validation is against `cimg/node:20.20` in CI, which is where the failure originates. Once published as 1.8.2, downstream consumers can `npm install @snyk/node-dump-stacks@^1.8.2` and confirm the install hook completes there.

## Release note

Recommend a **patch release (1.8.2)** via semantic-release — the existing `fix:` commit message will trigger that automatically. After publish, downstream consumers can drop any `nan` overrides they added as a workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)